### PR TITLE
Bump to version 1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='virtualtime',
-    version='1.2',
+    version='1.3',
     packages=['virtualtime', 'virtualtime.datetime_tz'],
     license='Apache License, Version 2.0',
     description='Implements a system for simulating a virtual time.',

--- a/virtualtime/datetime_tz/__init__.py
+++ b/virtualtime/datetime_tz/__init__.py
@@ -7,7 +7,7 @@ import datetime_tz as base_datetime_tz
 assert issubclass(base_datetime_tz.datetime_tz, patched_datetime_type), 'The base datetime_tz package must not be imported before virtualtime'
 
 from datetime_tz import detect_timezone, iterate, localtz
-from datetime_tz import localtz_set, timedelta, localize, get_naive, localtz_name, require_timezone
+from datetime_tz import localtz_set, timedelta, get_naive, localtz_name, require_timezone
 
 class datetime_tz(base_datetime_tz.datetime_tz):
 


### PR DESCRIPTION
@davidfraser  fixed an issue with localize (but neglected to remove an import he then overrode), but we never released a new version, which means we're not using this fix.  It is critical, so this bumps the version so we can release 1.3.